### PR TITLE
Fix - SmartwaiverTemplateData: Correct addParticipant

### DIFF
--- a/src/Smartwaiver/Types/Data/SmartwaiverTemplateData.php
+++ b/src/Smartwaiver/Types/Data/SmartwaiverTemplateData.php
@@ -116,7 +116,7 @@ class SmartwaiverTemplateData implements SmartwaiverInputType
                 $participant['dob'] = $dob;
             }
 
-            if (!isset($this->participants) || is_array($this->participants)) $this->participants = [];
+            if (!isset($this->participants) || !is_array($this->participants)) $this->participants = [];
             array_push($this->participants, $participant);
         }
     }


### PR DESCRIPTION
The `addParticipant` method was reinitializing the participants array after each use.